### PR TITLE
add api key authentication

### DIFF
--- a/backend/api/middleware/auth.py
+++ b/backend/api/middleware/auth.py
@@ -9,8 +9,8 @@ import os
 class AuthMiddleware(MiddlewareMixin):
     def process_request(self, request):
         try:
-            decoded = base64.b64decode(request.headers.get('Authorization'))
-            if not 'Authorization' in request.headers or decoded.decode('ascii') != os.environ.get('API_KEY'):
+            header = request.headers.get('Authorization')
+            if header is None or base64.b64decode(header).decode('ascii') != os.environ.get('API_KEY'):
                 return HttpResponse('Unauthorized', status=401)
         except binascii.Error:
             return HttpResponse('Unauthorized', status=401)

--- a/backend/api/middleware/auth.py
+++ b/backend/api/middleware/auth.py
@@ -1,0 +1,18 @@
+from django.utils.deprecation import MiddlewareMixin
+from django.http import HttpResponse
+import base64
+import binascii
+
+import os
+
+
+class AuthMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        try:
+            decoded = base64.b64decode(request.headers.get('Authorization'))
+            if not 'Authorization' in request.headers or decoded.decode('ascii') != os.environ.get('API_KEY'):
+                return HttpResponse('Unauthorized', status=401)
+        except binascii.Error:
+            return HttpResponse('Unauthorized', status=401)
+        else:
+            return None

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -52,7 +52,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.common.CommonMiddleware',
+    'api.middleware.auth.AuthMiddleware'
 ]
 
 CORS_ORIGIN_ALLOW_ALL = True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     environment: 
       DB_HOST: postgres_local
+      API_KEY: Woh5Toh4aerai6th
     volumes:
     - ./backend:/code
     ports:


### PR DESCRIPTION
closes #44 

This code requires an environment variable called `API_KEY` to be set. When its set, all requests must provide the header `Authorization` with the base64 encoded value of the api key.

```
$ curl http://localhost:8000/_health
Unauthorized     

$ curl http://localhost:8000/_health -H "Authorization: V29oNVRvaDRhZXJhaTZ0aA=="          
OK
```