### PR TITLE
Feature/graphs

### DIFF
--- a/backend/viewModule/views.py
+++ b/backend/viewModule/views.py
@@ -323,17 +323,17 @@ def top_facility_releases(request):
             geoFilter(request) & Q(year=y)).values('facility__name')
 
         if release_type == 'AIR':
-            queryset = queryset.annotate(air=Sum('air')).order_by('-air')
+            queryset = queryset.annotate(total=Sum('air')).order_by('-total')
         elif release_type == 'WATER':
-            queryset = queryset.annotate(water=Sum('water')).order_by('-water')
+            queryset = queryset.annotate(total=Sum('water')).order_by('-total')
         elif release_type == 'LAND':
-            queryset = queryset.annotate(land=Sum('land')).order_by('-land')
+            queryset = queryset.annotate(total=Sum('land')).order_by('-total')
         elif release_type == 'ON_SITE':
             queryset = queryset.annotate(
-                on_site=Sum('on_site')).order_by('-on_site')
+                total=Sum('on_site')).order_by('-total')
         elif release_type == 'OFF_SITE':
             queryset = queryset.annotate(
-                off_site=Sum('off_site')).order_by('-off_site')
+                total=Sum('off_site')).order_by('-total')
         else:
             queryset = queryset.annotate(total=Sum('total')).annotate(air=Sum('air')).annotate(water=Sum('water')).annotate(
                 land=Sum('land')).annotate(on_site=Sum('on_site')).annotate(off_site=Sum('off_site')).order_by('-total')

--- a/frontend/src/GraphView/index.js
+++ b/frontend/src/GraphView/index.js
@@ -122,10 +122,11 @@ async function GraphTopTenFacilities(props) {
         return {
           name: f.facility__name,
           total: f.total,
-          av: f.air,
-          bv: f.water,
-          cv: f.land,
-          dv: f.off_site,
+          av: f.air || 0,
+          bv: f.water || 0,
+          cv: f.land || 0,
+          dv: f.on_site || 0,
+          ev: f.off_site || 0,
         };
       })
       .sort((a, b) => b.total - a.total);
@@ -168,8 +169,14 @@ async function GraphTopTenFacilities(props) {
             <Bar name="water" dataKey="bv" stackId="a" fill={barColors.water} />
             <Bar name="land" dataKey="cv" stackId="a" fill={barColors.land} />
             <Bar
-              name="off-site"
+              name="on-site"
               dataKey="dv"
+              stackId="a"
+              fill={barColors.onSite}
+            />
+            <Bar
+              name="off-site"
+              dataKey="ev"
               stackId="a"
               fill={barColors.offSite}
             />

--- a/frontend/src/GraphView/index.js
+++ b/frontend/src/GraphView/index.js
@@ -165,18 +165,35 @@ async function GraphTopTenFacilities(props) {
               itemSorter={(a) => -a.value}
             />
             <Legend align="right" verticalAlign="top" />
-            <Bar name="air" dataKey="av" stackId="a" fill={barColors.air} />
-            <Bar name="water" dataKey="bv" stackId="a" fill={barColors.water} />
-            <Bar name="land" dataKey="cv" stackId="a" fill={barColors.land} />
+            <Bar
+              name="air"
+              dataKey={props.filters.releaseType === "air" ? "total" : "av"}
+              stackId="a"
+              fill={barColors.air}
+            />
+            <Bar
+              name="water"
+              dataKey={props.filters.releaseType === "water" ? "total" : "bv"}
+              stackId="a"
+              fill={barColors.water}
+            />
+            <Bar
+              name="land"
+              dataKey={props.filters.releaseType === "land" ? "total" : "cv"}
+              stackId="a"
+              fill={barColors.land}
+            />
             <Bar
               name="on-site"
-              dataKey="dv"
+              dataKey={
+                props.filters.releaseType === "off_site" ? "total" : "dv"
+              }
               stackId="a"
               fill={barColors.onSite}
             />
             <Bar
               name="off-site"
-              dataKey="ev"
+              dataKey={props.filters.releaseType === "on_site" ? "total" : "ev"}
               stackId="a"
               fill={barColors.offSite}
             />
@@ -457,10 +474,11 @@ async function GraphTopTenParents(props) {
         return {
           name: f.facility__parent_co_name,
           total: f.total,
-          av: f.air,
-          bv: f.water,
-          cv: f.land,
-          dv: f.off_site,
+          av: f.air || 0,
+          bv: f.water || 0,
+          cv: f.land || 0,
+          dv: f.on_site || 0,
+          ev: f.off_site || 0,
         };
       })
       .sort((a, b) => b.total - a.total);
@@ -499,12 +517,35 @@ async function GraphTopTenParents(props) {
               itemSorter={(a) => -a.value}
             />
             <Legend align="right" verticalAlign="top" />
-            <Bar name="air" dataKey="av" stackId="a" fill={barColors.air} />
-            <Bar name="water" dataKey="bv" stackId="a" fill={barColors.water} />
-            <Bar name="land" dataKey="cv" stackId="a" fill={barColors.land} />
+            <Bar
+              name="air"
+              dataKey={props.filters.releaseType === "air" ? "total" : "av"}
+              stackId="a"
+              fill={barColors.air}
+            />
+            <Bar
+              name="water"
+              dataKey={props.filters.releaseType === "water" ? "total" : "bv"}
+              stackId="a"
+              fill={barColors.water}
+            />
+            <Bar
+              name="land"
+              dataKey={props.filters.releaseType === "land" ? "total" : "cv"}
+              stackId="a"
+              fill={barColors.land}
+            />
+            <Bar
+              name="on-site"
+              dataKey={
+                props.filters.releaseType === "off_site" ? "total" : "dv"
+              }
+              stackId="a"
+              fill={barColors.onSite}
+            />
             <Bar
               name="off-site"
-              dataKey="dv"
+              dataKey={props.filters.releaseType === "on_site" ? "total" : "ev"}
               stackId="a"
               fill={barColors.offSite}
             />

--- a/frontend/src/GraphView/index.js
+++ b/frontend/src/GraphView/index.js
@@ -38,6 +38,9 @@ const barColors = {
   land: "#844b11",
 };
 
+const barAspectRatio = 12 / 9;
+const timelineAspectRatio = 16 / 9;
+
 function handleError(err) {
   /* do something here */
 }
@@ -128,7 +131,7 @@ async function GraphTopTenFacilities(props) {
       .sort((a, b) => b.total - a.total);
     return (
       <div>
-        <ResponsiveContainer width="100%" aspect={16 / 9}>
+        <ResponsiveContainer width="100%" aspect={barAspectRatio}>
           <BarChart
             data={data}
             margin={{
@@ -296,7 +299,7 @@ async function GraphTopTenPBTs(props) {
       .sort((a, b) => b.pv - a.pv);
     return (
       <div>
-        <ResponsiveContainer width="100%" aspect={16 / 9}>
+        <ResponsiveContainer width="100%" aspect={barAspectRatio}>
           <BarChart
             data={data}
             margin={{
@@ -456,7 +459,7 @@ async function GraphTopTenParents(props) {
       .sort((a, b) => b.total - a.total);
     return (
       <div>
-        <ResponsiveContainer width="100%" aspect={16 / 9}>
+        <ResponsiveContainer width="100%" aspect={barAspectRatio}>
           <BarChart
             data={data}
             margin={{
@@ -532,7 +535,7 @@ async function GraphTopTenChemicals(props) {
       .sort((a, b) => b.pv - a.pv);
     return (
       <div>
-        <ResponsiveContainer width="100%" aspect={16 / 9}>
+        <ResponsiveContainer width="100%" aspect={barAspectRatio}>
           <BarChart
             data={data}
             margin={{
@@ -637,7 +640,7 @@ async function TimelineTopFacilities(props) {
       ));
     return (
       <div>
-        <ResponsiveContainer width="100%" aspect={16 / 7}>
+        <ResponsiveContainer width="100%" aspect={timelineAspectRatio}>
           <LineChart data={data}>
             <CartesianGrid vertical={false} />
             <XAxis dataKey="year" />
@@ -732,7 +735,7 @@ async function TimelineTopParents(props) {
       ));
     return (
       <div>
-        <ResponsiveContainer width="100%" aspect={16 / 7}>
+        <ResponsiveContainer width="100%" aspect={timelineAspectRatio}>
           <LineChart width={500} height={300} data={data}>
             <CartesianGrid vertical={false} />
             <XAxis dataKey="year" />
@@ -826,7 +829,7 @@ async function TimelineTopChemicals(props) {
       ));
     return (
       <div>
-        <ResponsiveContainer width="100%" aspect={16 / 7}>
+        <ResponsiveContainer width="100%" aspect={timelineAspectRatio}>
           <LineChart width={500} height={300} data={data}>
             <CartesianGrid vertical={false} />
             <XAxis dataKey="year" />

--- a/frontend/src/Graphs/TimelineTotal.js
+++ b/frontend/src/Graphs/TimelineTotal.js
@@ -44,7 +44,7 @@ function TimelineTotal(props) {
       });
       const body = (
         <div>
-          <ResponsiveContainer width="100%" aspect={16 / 7}>
+          <ResponsiveContainer width="100%" aspect={16 / 9}>
             <LineChart width={500} height={300} data={res.data}>
               <CartesianGrid vertical={false} />
               <XAxis dataKey="year" />

--- a/frontend/src/UserControlPanel/index.js
+++ b/frontend/src/UserControlPanel/index.js
@@ -72,14 +72,7 @@ function UserControlPanel(props) {
   }
 
   function getReleaseTypes() {
-    const types = [
-      "All release types",
-      "air",
-      "water",
-      "land",
-      "off_site",
-      "on_site",
-    ];
+    const types = ["all", "air", "water", "land", "off_site", "on_site"];
 
     return types.map((type) => {
       return <option key={type}>{type}</option>;


### PR DESCRIPTION
Bar graphs now properly respond to release type filters by showing only the section of the stacked bar graph that corresponds to that release type. Selecting `air` now properly shows the 10 top companies by air releases only. 